### PR TITLE
Removable control

### DIFF
--- a/src/Control.Loading.js
+++ b/src/Control.Loading.js
@@ -112,13 +112,11 @@ L.Control.Loading = L.Control.extend({
         return e.target._leaflet_id;
     },
 
-    _layerEventHandlers: {
-        loading: this._handleLoading,
-        load: this._handleLoad,
-    },
-
     _layerAdd: function(e) {
-        e.layer.on(this._layerEventHandlers, this);
+        e.layer.on({
+            loading: this._handleLoading,
+            load: this._handleLoad,
+        }, this);
     },
 
     _addLayerListeners: function(map) {
@@ -126,7 +124,10 @@ L.Control.Loading = L.Control.extend({
         // map
         if (map._layers) {
             for (var index in map._layers) {
-                map._layers[index].on(this._layerEventHandlers, this);
+                map._layers[index].on({
+                    loading: this._handleLoading,
+                    load: this._handleLoad,
+                }, this);
             }
         }
 
@@ -139,7 +140,10 @@ L.Control.Loading = L.Control.extend({
         // Remove listeners for begin and end of load from all layers
         if (map._layers) {
             for (var index in map._layers) {
-                map._layers[index].off(this._layerEventHandlers);
+                map._layers[index].off({
+                    loading: this._handleLoading,
+                    load: this._handleLoad,
+                });
             }
         }
 


### PR DESCRIPTION
It follows from the ability to add a control to the map that one should also be able to remove that control. This enables the ability to remove the loading control.

The code follows L.Control.ZoomControl closely, but this means map.loadingControl is not guaranteed to exist. That's okay since the control always references itself directly (rather than through its instance assumed to be attached to the map).
