### PR TITLE
Fix Dangling Container on Remove

### DIFF
--- a/src/Control.Loading.js
+++ b/src/Control.Loading.js
@@ -40,12 +40,19 @@ L.Control.Loading = L.Control.extend({
     },
 
     removeFrom: function (map) {
-        // Override Control.removeFrom() to avoid clobbering the entire
-        // _container, which is the same as zoomControl's
-        this._container.removeChild(this._indicator);
-        this._map = null;
-        this.onRemove(map);
-        return this;
+        if (map.zoomControl && !this.options.separate) {
+            // Override Control.removeFrom() to avoid clobbering the entire
+            // _container, which is the same as zoomControl's
+            this._container.removeChild(this._indicator);
+            this._map = null;
+            this.onRemove(map);
+            return this;
+        }
+        else {
+            // If this control is separate from the zoomControl, call the
+            // parent method so we don't leave behind an empty container
+            return L.Control.prototype.removeFrom.call(this, map);
+        }
     },
 
     addLoader: function(id) {


### PR DESCRIPTION
If the loadingControl was separate from the zoomControl, removing it left behind its container. This fixes the issue by calling the overridden removeFrom() method when the indicator is separate.
