### PR TITLE
Get last button visible button instead zoomOut button

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ See Leaflet.loading in action (zoom or pan to make tiles load):
  - With the loading indicator and zoom control on the [top right][topright] of
    the map.
  - The [simplest example using spin.js](http://ebrelsford.github.io/Leaflet.loading/spinjs.html) instead of an image
+ - Combined with a [fullscreen control][combined] (e.g. [https://github.com/brunob/leaflet.fullscreen]).
 
 
 ## License
@@ -84,3 +85,4 @@ License.
  [simple]: http://ebrelsford.github.io/Leaflet.loading/simple.html
  [separate]: http://ebrelsford.github.io/Leaflet.loading/separate.html
  [topright]: http://ebrelsford.github.io/Leaflet.loading/topright.html
+ [combined]: http://ebrelsford.github.io/Leaflet.loading/combined.html

--- a/examples/combined.html
+++ b/examples/combined.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Leaflet.loading example&mdash;simple</title>
+
+        <!-- Include Leaflet -->
+        <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
+        <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
+
+        <!-- Include the fullscreen control -->
+        <script src='//rawgithub.com/brunob/leaflet.fullscreen/master/Control.FullScreen.js'></script>
+        <style>
+            /* Styles are copied from: http://brunob.github.io/leaflet.fullscreen/ */
+            /* one selector per rule as explained here : http://www.sitepoint.com/html5-full-screen-api/ */
+            #map:-webkit-full-screen { width: 100% !important; height: 100% !important; z-index: 99999; }
+            #map:-moz-full-screen { width: 100% !important; height: 100% !important; z-index: 99999; }
+            #map:full-screen { width: 100% !important; height: 100% !important; z-index: 99999; }
+            .leaflet-pseudo-fullscreen { position: fixed !important; width: 100% !important; height: 100% !important; top: 0px !important; left: 0px !important; z-index: 99999; }
+            .leaflet-control-zoom-fullscreen { background-image: url(https://github.com/brunob/leaflet.fullscreen/raw/master/icon-fullscreen.png); }
+            .leaflet-retina .leaflet-control-zoom-fullscreen { background-image: url(https://github.com/brunob/leaflet.fullscreen/raw/master/icon-fullscreen-2x.png); background-size: 26px 26px; }
+        </style>
+
+        <!-- Include the loading control -->
+        <!-- Be aware of the loading order. Both controls (fullscreen and loading are using the Map.addInitHook).
+             So first loaded will be displayed first. To avoid it add the loading control manually. -->
+        <link rel="stylesheet" href="../src/Control.Loading.css" />
+        <script src="../src/Control.Loading.js"></script>
+    </head>
+    <body>
+
+        <div id="map" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></div>
+
+        <script>
+                var openStreetMap = L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+                    attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+                }),
+
+                map = new L.Map('map', {
+                    layers: [openStreetMap],
+                    center: new L.LatLng(40.65,-73.95),
+                    zoom: 12,
+
+                    // Tell the map to use a loading control
+                    loadingControl: true,
+
+                    // Tell the map to use a fullsreen control
+                    fullscreenControl: true
+                });
+        </script>
+    </body>
+</html>

--- a/src/Control.Loading.js
+++ b/src/Control.Loading.js
@@ -58,6 +58,10 @@
                     container = this.zoomControl._container;
                     // These classes are no longer used as of Leaflet 0.6
                     classes += ' leaflet-bar-part-bottom leaflet-bar-part last';
+
+                    // Loading control will be added to the zoom control. So the visible last element is not the
+                    // last dom element anymore. So add the part-bottom class.
+                    L.DomUtil.addClass(this._getLastControlButton(), 'leaflet-bar-part-bottom');
                 }
                 else {
                     // Otherwise, create a container for the indicator

--- a/src/Control.Loading.js
+++ b/src/Control.Loading.js
@@ -130,7 +130,7 @@
                 // If zoomControl exists, make the zoom-out button not last
                 if (!this.options.separate) {
                     if (this.zoomControl instanceof L.Control.Zoom) {
-                        L.DomUtil.removeClass(this.zoomControl._zoomOutButton, 'leaflet-bar-part-bottom');
+                        L.DomUtil.removeClass(this._getLastControlButton(), 'leaflet-bar-part-bottom');
                     }
                     else if (typeof L.Control.Zoomslider === 'function' && this.zoomControl instanceof L.Control.Zoomslider) {
                         L.DomUtil.removeClass(this.zoomControl._ui.zoomOut, 'leaflet-bar-part-bottom');
@@ -145,12 +145,26 @@
                 // If zoomControl exists, make the zoom-out button last
                 if (!this.options.separate) {
                     if (this.zoomControl instanceof L.Control.Zoom) {
-                        L.DomUtil.addClass(this.zoomControl._zoomOutButton, 'leaflet-bar-part-bottom');
+                        L.DomUtil.addClass(this._getLastControlButton(), 'leaflet-bar-part-bottom');
                     }
                     else if (typeof L.Control.Zoomslider === 'function' && this.zoomControl instanceof L.Control.Zoomslider) {
                         L.DomUtil.addClass(this.zoomControl._ui.zoomOut, 'leaflet-bar-part-bottom');
                     }
                 }
+            },
+
+            _getLastControlButton: function() {
+                var container = this.zoomControl._container,
+                    index     = container.children.length-1;
+
+                // Find first visible control button.
+                while (index > 0 && (this._indicator == container.children[index]
+                    || container.children[index].offsetWidth == 0
+                    || container.children[index].offsetHeight == 0)) {
+                    index--;
+                }g
+
+                return container.children[index];
             },
 
             _handleLoading: function(e) {

--- a/src/Control.Loading.js
+++ b/src/Control.Loading.js
@@ -162,7 +162,7 @@
                     || container.children[index].offsetWidth == 0
                     || container.children[index].offsetHeight == 0)) {
                     index--;
-                }g
+                };
 
                 return container.children[index];
             },


### PR DESCRIPTION
When using other controls (e.g. a fullscreen control) which are rendered as part of the zoom control, toggling the `leaflet-bar-part-bottom` of the zoomOut button is not what's wanted.

This pull request uses the last visible button for toggle the state. Instead of getting the 2nd last button in the row, I've made and secure checking for the first visible one. Maybe overimplemented but who knows how it's used.

I don't have any experience of the zoomslider. So I've added it only to the standard zoom control.