### PR TITLE
Add CSS file to Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,10 @@
     "Eric Brelsford <ebrelsford@gmail.com>"
   ],
   "description": "A loading-indicator control for Leaflet",
-  "main": "src/Control.Loading.js",
+  "main": [
+    "src/Control.Loading.css",
+    "src/Control.Loading.js"
+  ],
   "keywords": [
     "leaflet",
     "map",


### PR DESCRIPTION
If CSS is not present in the definition, a bower install command will not add the CSS to your project, in which case you will have to add it manually.