### PR TITLE
Update Control.Loading.js namespace

### DIFF
--- a/src/Control.Loading.js
+++ b/src/Control.Loading.js
@@ -332,7 +332,7 @@
             }
         });
 
-        L.Control.loading = function(options) {
+        L.control.loading = function(options) {
             return new L.Control.Loading(options);
         };
     }


### PR DESCRIPTION
more lefleat plugins having this standard namespace "L.control.nameplugin" with _control_ all lowercase